### PR TITLE
Pass payload data to query params for GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Twitter](https://img.shields.io/twitter/follow/kevinrwhitley.svg?style=social&label=Follow)](https://www.twitter.com/kevinrwhitley)
 
 
-Super lightweight (~570 bytes) wrapper to simplify native fetch calls using *any* HTTP method (existing or imagined).
+Super lightweight (~560 bytes) wrapper to simplify native fetch calls using *any* HTTP method (existing or imagined).
 
 ## Features
 - Fully typed/TypeScript support

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Twitter](https://img.shields.io/twitter/follow/kevinrwhitley.svg?style=social&label=Follow)](https://www.twitter.com/kevinrwhitley)
 
 
-Super lightweight (~570 bytes on desk, before Brotli compression) wrapper to simplify native fetch calls using *any* HTTP method (existing or imagined).
+Super lightweight (~570 bytes) wrapper to simplify native fetch calls using *any* HTTP method (existing or imagined).
 
 ## Features
 - Fully typed/TypeScript support

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Twitter](https://img.shields.io/twitter/follow/kevinrwhitley.svg?style=social&label=Follow)](https://www.twitter.com/kevinrwhitley)
 
 
-Super lightweight (~560 bytes) wrapper to simplify native fetch calls using *any* HTTP method (existing or imagined).
+Super lightweight (~590 bytes) wrapper to simplify native fetch calls using *any* HTTP method (existing or imagined).
 
 ## Features
 - Fully typed/TypeScript support

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Twitter](https://img.shields.io/twitter/follow/kevinrwhitley.svg?style=social&label=Follow)](https://www.twitter.com/kevinrwhitley)
 
 
-Super lightweight (~450 bytes) wrapper to simplify native fetch calls using *any* HTTP method (existing or imagined).
+Super lightweight (~570 bytes on desk, before Brotli compression) wrapper to simplify native fetch calls using *any* HTTP method (existing or imagined).
 
 ## Features
 - Fully typed/TypeScript support

--- a/src/itty-fetcher.spec.ts
+++ b/src/itty-fetcher.spec.ts
@@ -112,22 +112,46 @@ describe('fetcher', () => {
       expect(response).toEqual(JSON_RESPONSE)
     })
 
-    it('passes data for GET requests into query params', async () => {
-      const url = 'https://google.com'
-      const data = { foo: 'hello world!', baz: 10, biz: true, }
+    describe('GET', () => {
+      it('passes data into query params', async () => {
+        const url = 'https://google.com'
+        const data = { foo: 'hello world!', baz: 10, biz: true, bop: ["a", "b"] }
 
-      const expected = new URL(url)
-      for (const [key, val] of Object.entries(data)) {
-        expected.searchParams.set(key, String(val))
-      }
+        const expected = new URL(url)
+        for (const [key,val] of Object.entries(data)) {
+         expected.searchParams.set(key, String(val)) 
+        }
 
-      const mock = fetchMock.get(expected.toString(), data)
+        const mock = fetchMock.get(expected.toString(), data)
 
-      await fetcher().get(url, data)
+        await fetcher().get(url, data)
 
-      const [uri, init] = mock.calls()[0]
-      expect(uri).toEqual(expected.toString())
-      expect(init?.body).toBeUndefined()
+        const [uri, init] = mock.calls()[0]
+        expect(uri).toEqual(expected.toString())
+        expect(init?.body).toBeUndefined()
+      })
+
+      it('can pass in custom URLSearchParams', async () => {
+        const url = 'https://google.com'
+        const data = { foo: 'hello world!', baz: 10, biz: true,bop: ["a", "b"] }
+        const params = new URLSearchParams()
+        params.set('foo', data.foo)
+        params.set('baz', String(data.baz))
+        params.set('biz', String(data.biz))
+        params.append('bop', data.bop[0])
+        params.append('bop', data.bop[1])
+
+        const expected = new URL(url)
+        expected.search = params.toString()
+
+        const mock = fetchMock.get(expected.toString(), [])
+
+        await fetcher().get(url, params)
+
+        const [uri, init] = mock.calls()[0]
+        expect(uri).toEqual(expected.toString())
+        expect(init?.body).toBeUndefined()
+      })
     })
 
     describe('options (use native fetch options)', () => {

--- a/src/itty-fetcher.spec.ts
+++ b/src/itty-fetcher.spec.ts
@@ -12,18 +12,20 @@ const JSON_RESPONSE = [ 'apple', 'bat', 'cat']
 const STRING_RESPONSE = 'https://foo.bar/string'
 const ERROR_RESPONSE = 400
 
-fetchMock
-  .get(URL_JSON, JSON_RESPONSE)
-  .get(URL_STRING, STRING_RESPONSE)
-  .get(URL_ERROR, ERROR_RESPONSE)
-  .patch(URL_JSON, JSON_RESPONSE, {
-    headers: {
-      'content-type': 'application/json',
-    }
-  })
-
-// BEGIN TESTS
 describe('fetcher', () => {
+  beforeEach(() => {
+    fetchMock.reset()
+    fetchMock
+      .get(URL_JSON, JSON_RESPONSE)
+      .get(URL_STRING, STRING_RESPONSE)
+      .get(URL_ERROR, ERROR_RESPONSE)
+      .patch(URL_JSON, JSON_RESPONSE, {
+        headers: {
+          'content-type': 'application/json',
+        },
+      })
+  })
+  
   const defaults = fetcher()
 
   it('default import is a function', () => {
@@ -108,6 +110,24 @@ describe('fetcher', () => {
       const response = await fetcher().get<ArrayOfNumbers>(URL_JSON)
 
       expect(response).toEqual(JSON_RESPONSE)
+    })
+
+    it('passes data for GET requests into query params', async () => {
+      const url = 'https://google.com'
+      const data = { foo: 'hello world!', baz: 10, biz: true, }
+
+      const expected = new URL(url)
+      for (const [key, val] of Object.entries(data)) {
+        expected.searchParams.set(key, String(val))
+      }
+
+      const mock = fetchMock.get(expected.toString(), data)
+
+      await fetcher().get(url, data)
+
+      const [uri, init] = mock.calls()[0]
+      expect(uri).toEqual(expected.toString())
+      expect(init?.body).toBeUndefined()
     })
 
     describe('options (use native fetch options)', () => {

--- a/src/itty-fetcher.ts
+++ b/src/itty-fetcher.ts
@@ -45,12 +45,21 @@ const fetchy = (options: FetchyOptions): FetchyFunction => (
   /**
    * If the request is a `.get(...)` then we want to pass the payload
    * to the URL as query params as passing data in the body is not
-   * allowed for GET requests. We clear the payload after this so that
-   * it doesn't get passed to the body.
+   * allowed for GET requests.
+   * 
+   * If the user passes in a URLSearchParams object, we'll use that,
+   * otherwise we will create a new URLSearchParams object from the payload 
+   * and pass that in.
+   * 
+   * We clear the payload after this so that it doesn't get passed to the body.
    */
   if (method === 'GET' && payload && typeof payload === 'object') {
-    resolvedURL.search = new URLSearchParams(
-      payload as Record<string, string>
+    resolvedURL.search = (
+      payload instanceof URLSearchParams
+          ? payload
+          : new URLSearchParams(
+            payload as Record<string, string>
+          )
     ).toString()
     payload = undefined
   }

--- a/src/itty-fetcher.ts
+++ b/src/itty-fetcher.ts
@@ -56,7 +56,7 @@ const fetchy = (options: FetchyOptions): FetchyFunction => (
   }
 
   return fetch(resolvedURL.toString(), {
-    method: method.toUpperCase(),
+    method,
     ...fetchOptions,
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
Added tests. Note that I had to move the tests into a `beforeEach` so I can assert against the `calls` otherwise I get all them mock calls in the test.

Adds about 110 bytes, not sure if it is possible to reduce further.