### PR TITLE
Allow a custom fetch method

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Returns a fetcher object, with method calls (like `.get`, `.post`, etc) mapped t
 | **autoParse**        | `boolean`                               | `true`                 | By default, all responses are parsed to JSON/text/etc. To access the Response directly, set this to false.                                                                                                                                 |
 | **base**             | `string`                                | `''` (an empty string) | Use this to prefix all future fetch calls, for example `{ base: "https://api.foo.bar/v1" }`, allows future calls such as `fetcher.get('/kittens/14')` to work by automatically prepending the base URL.                                    |
 | **transformRequest** | `(request: RequestLike) => RequestLike` | `undefined`            | An optional method that allows for transforming a request before it is sent. This is useful for adding headers, etc. The method is passed the request object, and should return the request object (or a new one). See below for examples. |
+| **fetch**            | `typeof fetch`                          | `undefined`            | An optional implementation of `fetch` that will be used instead of the built-in `fetch` on all requests. This is useful when your may need to work with a modified version of fetch, like SvelteKit's `load` function.                     |
 
 `RequestLike` matches the following signature:
 

--- a/src/itty-fetcher.spec.ts
+++ b/src/itty-fetcher.spec.ts
@@ -1,6 +1,6 @@
 import fetchMock from 'fetch-mock'
 import 'isomorphic-fetch'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetcher, FetcherOptions, RequestPayload } from './itty-fetcher'
 
 describe('fetcher', () => {
@@ -39,6 +39,14 @@ describe('fetcher', () => {
         fetchMock.get('/', {})
         const response: object = await fetcher({ autoParse: false }).get('/')
         expect(response.constructor.name).toBe('Response')
+      })
+    })
+
+    describe('fetch', () => {
+      it('can pass in a custom fetch implementation', () => {
+        const custom_fetch = vi.fn().mockResolvedValue(new Response('works!')) as typeof fetch
+        fetcher({ fetch: custom_fetch }).get('/foo')
+        expect(custom_fetch).toBeCalled()
       })
     })
   })

--- a/src/itty-fetcher.spec.ts
+++ b/src/itty-fetcher.spec.ts
@@ -46,7 +46,11 @@ describe('fetcher', () => {
       it('can pass in a custom fetch implementation', () => {
         const custom_fetch = vi.fn().mockResolvedValue(new Response('works!')) as typeof fetch
         fetcher({ fetch: custom_fetch }).get('/foo')
-        expect(custom_fetch).toBeCalled()
+        expect(custom_fetch).toBeCalledWith('/foo', {
+          method: 'GET',
+          body: undefined,
+          headers: { 'Content-Type': 'application/json' },
+        })
       })
     })
   })

--- a/src/itty-fetcher.ts
+++ b/src/itty-fetcher.ts
@@ -10,7 +10,7 @@ export interface FetcherOptions {
   base?: string
   autoParse?: boolean
   transformRequest?: (request: RequestLike) => RequestLike
-  fetch: typeof fetch
+  fetch?: typeof fetch
 }
 
 type FetchyFunction = <T>(

--- a/src/itty-fetcher.ts
+++ b/src/itty-fetcher.ts
@@ -10,6 +10,7 @@ export interface FetcherOptions {
   base?: string
   autoParse?: boolean
   transformRequest?: (request: RequestLike) => RequestLike
+  fetch: typeof fetch
 }
 
 type FetchyFunction = <T>(
@@ -82,7 +83,9 @@ const fetchy =
 
     const { url, ...init } = req
 
-    return fetch(url, init).then((response) => {
+    const f = typeof options?.fetch === 'function' ? options.fetch : fetch
+
+    return f(url, init).then((response) => {
       if (response.ok) {
         if (!options.autoParse) return response
 


### PR DESCRIPTION
Add a config option `fetch` which takes a fetch implementation to replace the built-in fetch.

Added tests and a note in the readme.

Closes #12 