### PR TITLE
adds payload-as-blob support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog
 Until this library makes it to a production release of v1.x, **minor versions may contain breaking changes to the API**.  After v1.x, semantic versioning will be honored, and breaking changes will only occur under the umbrella of a major version bump.
 
-- **v0.7.0** - adds fetch config option for using non-native fetch libraries - [@danawoodman](https://github.com/danawoodman)
+- **v0.7.0** - adds fetch config option for using non-native fetch libraries - [@danawoodman](https://github.com/danawoodman), blob support [@danawoodman](https://github.com/danawoodman) and [@kwhitley](https://github.com/kwhitley)
 - **v0.6.0** - adds the ability to handle FormData payloads - [@danawoodman](https://github.com/danawoodman), yet again :)
 - **v0.5.0** - adds the transformRequest base config option for transforming requests before the final fetch (use to add headers, etc) - [@danawoodman](https://github.com/danawoodman)
 - **v0.4.0** - now does *not* require a fully-qualified URL (as base+path), to properly mirror native fetch

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ api.foo('/kitten/13', { name: 'Different Cat' }) // sends using FOO method
 await api.get('/names', { max: 2, foo: ['bar', 'baz'] })
 // GET https://api.kittens.com/v1/names?max=2&foo=bar&foo=baz
 
+// send files/blobs directly
+await api.post('/upload', new Blob(['some text'], { type: 'plain/text' }))
+
 // ERROR HANDLING: 400, 404, 500, etc will actually throw, allowing an easy catch
 api.get('/not-a-valid-path').catch(({ status, message }) => {
   console.log('received a status', status, 'error with message:', message)

--- a/src/itty-fetcher.spec.ts
+++ b/src/itty-fetcher.spec.ts
@@ -1,5 +1,5 @@
 import fetchMock from 'fetch-mock'
-import { beforeEach, describe, expect, it, Mock, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetcher, FetcherOptions, RequestPayload } from './itty-fetcher'
 
 describe('fetcher', () => {
@@ -49,7 +49,7 @@ describe('fetcher', () => {
         expect(custom_fetch).toBeCalledWith('/foo', {
           method: 'GET',
           body: undefined,
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'content-type': 'application/json' },
         })
       })
     })
@@ -116,8 +116,9 @@ describe('fetcher', () => {
       // Passing headers in init
       'will still embed content-type header if headers are included in fetch options': {
         method: 'patch',
+        payload: { foo: 'bar' },
         init: { headers: { A: 'a' } },
-        expected: { headers: { A: 'a', 'Content-Type': 'application/json' } },
+        expected: { headers: { A: 'a', 'content-type': 'application/json' } },
       },
       'can override Content-Type header': {
         init: { headers: { 'content-type': 'text/plain' } },
@@ -129,6 +130,13 @@ describe('fetcher', () => {
         method: 'post',
         payload: formdata,
         expected: { body: formdata },
+      },
+
+      // Manual body property
+      'will pass Blob as-is (no stringify or content-type injection)': {
+        method: 'post',
+        payload: new Blob(['foo'], { type: 'text/plain' }),
+        expected: { headers: {} },
       },
 
       // Manual body property

--- a/src/itty-fetcher.spec.ts
+++ b/src/itty-fetcher.spec.ts
@@ -136,7 +136,7 @@ describe('fetcher', () => {
       'will pass Blob as-is (no stringify or content-type injection)': {
         method: 'post',
         payload: new Blob(['foo'], { type: 'text/plain' }),
-        expected: { headers: {} },
+        expected: { body: new Blob(['foo'], { type: 'text/plain' }), headers: {} },
       },
 
       // Manual body property

--- a/src/itty-fetcher.ts
+++ b/src/itty-fetcher.ts
@@ -8,7 +8,7 @@ type FetchOptions = Omit<RequestInit, 'headers'> & {
   headers?: Record<string, string>
 }
 
-export type RequestPayload = string | number | object | any[] | FormData | undefined
+export type RequestPayload = string | number | object | any[] | FormData | Blob | undefined
 
 export interface FetcherOptions {
   base?: string
@@ -66,14 +66,16 @@ const fetchy =
     }
 
     const full_url = (options.base || '') + url_or_path + search
+    const passthrough: boolean = payload instanceof FormData || payload instanceof Blob
+    const jsonHeaders = !passthrough ? { 'content-type': 'application/json' } : undefined
 
     let req: RequestLike = {
       url: full_url,
       method,
-      body: payload instanceof FormData ? payload : JSON.stringify(payload),
+      body: (payload instanceof FormData || payload instanceof Blob) ? payload : JSON.stringify(payload),
       ...fetchOptions,
       headers: {
-        'Content-Type': 'application/json',
+        ...jsonHeaders,
         ...fetchOptions?.headers,
       },
     }

--- a/src/itty-fetcher.ts
+++ b/src/itty-fetcher.ts
@@ -66,7 +66,7 @@ const fetchy =
     }
 
     const full_url = (options.base || '') + url_or_path + search
-    const passthrough: boolean = payload instanceof FormData || payload instanceof Blob
+    const passthrough = payload instanceof FormData || payload instanceof Blob
     const jsonHeaders = !passthrough ? { 'content-type': 'application/json' } : undefined
 
     let req: RequestLike = {


### PR DESCRIPTION
# Changes
- **breaking:** no longer embeds `{ 'content-type': 'application/json' }` by default in headers.  This behavior now only occurs if on a non-passthrough payload/body type.
- will not `JSON.stringify` on type `FormData` or `Blob`... there's likely a more ideal way to check for valid body types?  Also what all types are even valid?