### PR TITLE
Export the FetcherType

### DIFF
--- a/src/itty-fetcher.ts
+++ b/src/itty-fetcher.ts
@@ -27,7 +27,7 @@ type FetchTraps = {
   [key: string]: FetchyFunction
 }
 
-type FetcherType = FetcherOptions & {
+export type FetcherType = FetcherOptions & {
   get: FetchyFunction
   post: FetchyFunction
   put: FetchyFunction


### PR DESCRIPTION
Exporting the FetcherType allows you to wrap itty-fetcher more easily:

```ts
export function api(args: Args): FetcherType {
  return fetcher({
    ...args,
    base: args.base.replace("/dev", "/prod"),
  });
}
```

That's a terrible example, but the core need is reasonable, especially if you're using other functions that expect to receive the FetcherType as a param (which I assume is going to be all over the place).