### PR TITLE
Add safe checking of payload data type to prevent undefined errors

### DIFF
--- a/src/itty-fetcher.spec.ts
+++ b/src/itty-fetcher.spec.ts
@@ -132,7 +132,7 @@ describe('fetcher', () => {
         expected: { body: formdata },
       },
 
-      // Manual body property
+      // Blob
       'will pass Blob as-is (no stringify or content-type injection)': {
         method: 'post',
         payload: new Blob(['foo'], { type: 'text/plain' }),


### PR DESCRIPTION
This fixed issues where Blob/FormData are being reported as undefined. It also makes our auto content-type/`JSON.stringify` code work more reliably. 

Also added checking for `Uint8Array`. May eventually need to support more content types. 

Thanks to @Crisfole for the tip on using `typeof FormData !== "undefined"`!

- Export all common types so consumers can use them if needed

Closes #16
Closes #21