### PR TITLE
[#25] Don't stringify the prototype of a payload

### DIFF
--- a/src/itty-fetcher.spec.ts
+++ b/src/itty-fetcher.spec.ts
@@ -138,6 +138,11 @@ describe('fetcher', () => {
         payload: new Blob(['foo'], { type: 'text/plain' }),
         expected: { body: new Blob(['foo'], { type: 'text/plain' }), headers: {} },
       },
+      'will pass Uint8Array as-is (no stringify or content-type injection)': {
+        method: 'post',
+        payload: new Uint8Array(new TextEncoder().encode('hello world')),
+        expected: { body: new Uint8Array(new TextEncoder().encode('hello world')), headers: {} },
+      },
 
       // Manual body property
       'can manually over the payload body in the init body': {

--- a/src/itty-fetcher.ts
+++ b/src/itty-fetcher.ts
@@ -77,7 +77,7 @@ const fetchy =
       typeof payload === 'string' ||
       typeof payload === 'number' ||
       Array.isArray(payload) ||
-      Object.getPrototypeOf(payload).toString() === '[object Object]'
+      Object.getPrototypeOf(payload).constructor.name === 'Object'
 
     const jsonHeaders = stringify ? { 'content-type': 'application/json' } : undefined
 


### PR DESCRIPTION
Previous code threw because TypedArrays/ArrayBuffers will fail when you attempt to Stringify their prototype, like Uin8Array.

Instead we get the constructor of the prototype and check its name, which is also a bit more elegant and explicity as a bonus.

Closes #25