### PR TITLE
Error Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 Until this library makes it to a production release of v1.x, **minor versions may contain breaking changes to the API**.  After v1.x, semantic versioning will be honored, and breaking changes will only occur under the umbrella of a major version bump.
 
+- **v0.8.0** - adds StatusError class (and status to thrown !response.ok Errors), and handleResponse fetcher option.
 - **v0.7.3** - better content-type-checking [@danawoodman](https://github.com/danawoodman)
 - **v0.7.0** - adds fetch config option for using non-native fetch libraries - [@danawoodman](https://github.com/danawoodman), blob support [@danawoodman](https://github.com/danawoodman) and [@kwhitley](https://github.com/kwhitley)
 - **v0.6.0** - adds the ability to handle FormData payloads - [@danawoodman](https://github.com/danawoodman), yet again :)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Tiny (~600 bytes) wrapper to simplify native `fetch` calls using _any_ HTTP meth
 - Accepts _any_ HTTP method (including user-defined)
 - 404, 400, 500, errors actually throw to allow easier catching
 - Still allows any native fetch options (including headers, etc) to be sent
-- allows full takeover of the Response chain
+- allows full takeover of the Response chain/error-handling
 
 ## Simple Usage
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Tiny (~600 bytes) wrapper to simplify native `fetch` calls using _any_ HTTP meth
 - Accepts _any_ HTTP method (including user-defined)
 - 404, 400, 500, errors actually throw to allow easier catching
 - Still allows any native fetch options (including headers, etc) to be sent
+- allows full takeover of the Response chain
 
 ## Simple Usage
 
@@ -118,6 +119,7 @@ Returns a fetcher object, with method calls (like `.get`, `.post`, etc) mapped t
 | **autoParse**        | `boolean`                               | `true`                 | By default, all responses are parsed to JSON/text/etc. To access the Response directly, set this to false.                                                                                                                                 |
 | **base**             | `string`                                | `''` (an empty string) | Use this to prefix all future fetch calls, for example `{ base: "https://api.foo.bar/v1" }`, allows future calls such as `fetcher.get('/kittens/14')` to work by automatically prepending the base URL.                                    |
 | **fetch**            | `typeof fetch`                          | `undefined`            | An optional implementation of `fetch` that will be used instead of the built-in `fetch` on all requests. This is useful when your may need to work with a modified version of fetch, like SvelteKit's `load` function.                     |
+| **handleResponse** | `(response: Response) => any` | `undefined` | An optional method to take over the response-handling (and throwing) of itty-fetcher. Using this will disregard the `autoParse` flag. This option allows for a transform to split responses into { data, error } shapes, for instance, to better align with await syntax. |
 | **transformRequest** | `(request: RequestLike) => RequestLike` | `undefined`            | An optional method that allows for transforming a request before it is sent. This is useful for adding headers, etc. The method is passed the request object, and should return the request object (or a new one). See below for examples. |
 
 `RequestLike` matches the following signature:

--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ await api.get('/names', { max: 2, foo: ['bar', 'baz'] })
 await api.post('/upload', new Blob(['some text'], { type: 'plain/text' }))
 
 // ERROR HANDLING: 400, 404, 500, etc will actually throw, allowing an easy catch
-api.get('/not-a-valid-path').catch(({ status, message }) => {
-  console.log('received a status', status, 'error with message:', message)
-})
+api
+  .get('/not-a-valid-path')
+  .catch(({ status, message }) => {
+    console.log('received a status', status, 'error with message:', message)
+  })
 ```
 
 ## Why yet another fetching library?

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/itty-fetcher.svg?style=flat-square)](https://npmjs.com/package/itty-fetcher)
 [![Bundle Size](https://img.shields.io/bundlephobia/minzip/itty-fetcher?style=flat-square)](https://bundlephobia.com/result?p=itty-fetcher)
-![Build Status](https://img.shields.io/github/workflow/status/kwhitley/itty-fetcher/build?style=flat-square)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/kwhitley/itty-fetcher/verify.yml?branch=v0.x&style=flat-square)](https://github.com/kwhitley/itty-router/actions/workflows/verify.yml)
 [![Coverage Status](https://img.shields.io/coveralls/github/kwhitley/itty-fetcher/v0.x?style=flat-square)](https://coveralls.io/github/kwhitley/itty-fetcher?branch=v0.x)
 [![NPM Weekly Downloads](https://img.shields.io/npm/dw/itty-fetcher?style=flat-square)](https://npmjs.com/package/itty-fetcher)
 [![Open Issues](https://img.shields.io/github/issues/kwhitley/itty-fetcher?style=flat-square)](https://github.com/kwhitley/itty-fetcher/issues)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-fetcher",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Tiny wrapper around native fetch to remove boilerplate from your own API fetching code.",
   "sourceType": "module",
   "main": "./dist/itty-fetcher.js",

--- a/src/itty-fetcher.spec.ts
+++ b/src/itty-fetcher.spec.ts
@@ -264,6 +264,15 @@ describe('fetcher', () => {
         },
         expected: { url: 'https://bar.com/' },
       },
+      'will use optional handleResponse option': {
+        options: {
+          base,
+          handleResponse: (response) => response.status,
+        },
+        expected: {
+          response: 200,
+        },
+      },
     }
 
     for (const [name, t] of Object.entries(tests)) {

--- a/src/itty-fetcher.spec.ts
+++ b/src/itty-fetcher.spec.ts
@@ -2,6 +2,8 @@ import fetchMock from 'fetch-mock'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetcher, FetcherOptions, RequestPayload } from './itty-fetcher'
 
+type StatusCode = string
+
 describe('fetcher', () => {
   beforeEach(() => {
     fetchMock.reset()
@@ -267,7 +269,7 @@ describe('fetcher', () => {
       'will use optional handleResponse option': {
         options: {
           base,
-          handleResponse: (response) => response.status,
+          handleResponse: (response): number => response.status,
         },
         expected: {
           response: 200,

--- a/src/itty-fetcher.spec.ts
+++ b/src/itty-fetcher.spec.ts
@@ -2,8 +2,6 @@ import fetchMock from 'fetch-mock'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetcher, FetcherOptions, RequestPayload } from './itty-fetcher'
 
-type StatusCode = string
-
 describe('fetcher', () => {
   beforeEach(() => {
     fetchMock.reset()

--- a/src/itty-fetcher.ts
+++ b/src/itty-fetcher.ts
@@ -26,7 +26,7 @@ export interface FetcherOptions {
   base?: string
   autoParse?: boolean
   transformRequest?: (request: RequestLike) => RequestLike,
-  handleResponse?: <T = any>(response: Response) => Promise<T>,
+  handleResponse?: (response: Response) => any,
   fetch?: typeof fetch
   headers?: Record<string, string>
 }

--- a/src/itty-fetcher.ts
+++ b/src/itty-fetcher.ts
@@ -1,6 +1,8 @@
 type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }
 
-class StatusError extends Error {
+export class StatusError extends Error {
+  status: number
+
   constructor(status = 500, message = 'Internal Error.') {
     super(message)
     this.status = status
@@ -113,9 +115,9 @@ const fetchy =
 
     const f = typeof options?.fetch === 'function' ? options.fetch : fetch
 
-    return f(url, init).then(async (response) => {
+    return f(url, init).then((response) => {
       if (options.handleResponse)
-        return await options.handleResponse(response)
+        return options.handleResponse(response)
 
       if (response.ok) {
         if (!options.autoParse) return response


### PR DESCRIPTION
### Changelog
- Adds (and exports) `StatusError` class, to allow downstream `catch(err => err.status)`
- Adds `handleResponse: (response: Response) => any` option to take over response/error handling.