### PR TITLE
v0.9 - WIP

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,9 @@
   "rules": {
     "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-unused-vars": "off"
+    "@typescript-eslint/no-unused-vars": "off",
+    "prefer-const": "off",
+    "quotes": ["error", "single", { "allowTemplateLiterals": true }],
+    "semi": ["error", "never"]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
   ],
   "rules": {
     "@typescript-eslint/ban-types": "off",
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-unused-vars": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![NPM Weekly Downloads](https://img.shields.io/npm/dw/itty-fetcher?style=flat-square)](https://npmjs.com/package/itty-fetcher)
 [![Open Issues](https://img.shields.io/github/issues/kwhitley/itty-fetcher?style=flat-square)](https://github.com/kwhitley/itty-fetcher/issues)
 
-[![Discord](https://img.shields.io/discord/832353585802903572?style=flat-square)](https://discord.com/channels/832353585802903572)
+[![Discord](https://img.shields.io/discord/832353585802903572?style=flat-square)](https://discord.gg/WQnqAsjhd6)
 [![GitHub Repo stars](https://img.shields.io/github/stars/kwhitley/itty-fetcher?style=social)](https://github.com/kwhitley/itty-fetcher)
 [![Twitter](https://img.shields.io/twitter/follow/kevinrwhitley.svg?style=social&label=Follow)](https://www.twitter.com/kevinrwhitley)
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -56,6 +56,34 @@ describe('fetcher', () => {
         })
       })
     })
+
+    describe('transformRequest', () => {
+      it('can modify the request before sending', async () => {
+        fetchMock.get('/', { status: 200, body: 'Success' })
+
+        const transformRequest = vi.fn(r => {
+          r.url = '/'
+          return r
+        })
+        const response = await fetcher({ transformRequest }).get('/foo')
+
+        expect(transformRequest).toHaveBeenCalled()
+        expect(response).toBe('Success')
+      })
+
+      it('can take an async function', async () => {
+        fetchMock.get('/', { status: 200, body: 'Success' })
+
+        const transformRequest = async (r) => {
+          r.url = await '/'
+          return r
+        }
+
+        const response = await fetcher({ transformRequest }).get('/foo')
+
+        expect(response).toBe('Success')
+      })
+    })
   })
 
   describe('error handling', () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -52,7 +52,7 @@ describe('fetcher', () => {
         expect(custom_fetch).toBeCalledWith('/foo', {
           method: 'GET',
           body: undefined,
-          headers: { 'content-type': 'application/json' },
+          headers: {},
         })
       })
     })

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -248,17 +248,17 @@ describe('fetcher', () => {
         expected: { url: base + '/?message=hello+world' },
       },
       'combines query params from the URL and the payload (object)': {
-        payload: { foo: 10 },
+        url: '/somewhere?foo=10',
+        payload: { foo: 12, bar: 'baz' },
         options: {
           base,
           transformRequest(req) {
-            const url = new URL(req.url)
-            url.searchParams.set('message', 'hello world')
-            req.url = url.toString()
+            console.log('base', base)
+            console.log('REQUEST', req.url)
             return req
           },
         },
-        expected: { url: base + '/?foo=10&message=hello+world' },
+        expected: { url: base + '/somewhere?foo=10&foo=12&bar=baz' },
       },
       'combines query params from the URL and the payload (URLSearchParams)': {
         payload: new URLSearchParams([

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -59,7 +59,23 @@ describe('fetcher', () => {
   })
 
   describe('error handling', () => {
-    it('will throw on error response', async () => {
+    it('without response body', async () => {
+      fetchMock.get('/', { status: 404 })
+      const response: any = await fetcher().get('/').catch(e => e)
+
+      expect(response.status).toBe(404)
+      expect(response.message).toBe('Not Found')
+    })
+
+    it('with text response body', async () => {
+      fetchMock.get('/', { status: 404, body: RANDOM_STRING })
+      const response: any = await fetcher().get('/').catch(e => e)
+
+      expect(response.status).toBe(404)
+      expect(response.message).toBe(RANDOM_STRING)
+    })
+
+    it('with JSON response body', async () => {
       fetchMock.get('/', {
         status: 404,
         body: { error: 'Not Found', details: RANDOM_STRING },
@@ -68,23 +84,9 @@ describe('fetcher', () => {
       const catchError = vi.fn(e => e)
       const response: any = await fetcher().get('/').catch(catchError)
 
-      expect(catchError).toHaveBeenCalled()
       expect(response.status).toBe(404)
-      // expect(typeof response.response).toBe('object')
       expect(response.details).toBe(RANDOM_STRING)
       expect(response.error).toBe('Not Found')
-    })
-
-    it('will handle text error responses', async () => {
-      fetchMock.get('/', {
-        status: 404,
-        body: RANDOM_STRING,
-      })
-      const catchError = vi.fn(e => e)
-      const response: any = await fetcher().get('/').catch(catchError)
-
-      expect(response.status).toBe(404)
-      expect(response.message).toBe(RANDOM_STRING)
     })
   })
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -17,7 +17,7 @@ describe('fetcher', () => {
 
   describe('config options', () => {
     describe('base', () => {
-      it("defaults to ''", () => {
+      it(`defaults to ''`, () => {
         expect(fetcher().base).toBe('')
       })
 
@@ -70,7 +70,7 @@ describe('fetcher', () => {
 
       expect(catchError).toHaveBeenCalled()
       expect(response.status).toBe(404)
-      expect(typeof response.response).toBe('object')
+      // expect(typeof response.response).toBe('object')
       expect(response.details).toBe(RANDOM_STRING)
       expect(response.error).toBe('Not Found')
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,6 @@ const fetchy =
 
       if (!response.ok) {
         error = new StatusError(response.status, response.statusText)
-        // error.$r = response
       } else if (!options.autoParse) return response
 
       const content = await (response.headers.get('content-type')?.includes('json') ? response.json() : response.text())

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,19 @@
 export class StatusError extends Error {
   status: number
-  #$r: Response
+  // #$r: Response
 
   constructor(status = 500, message = 'Internal Error.') {
     super(message)
     this.status = status
   }
 
-  get response() {
-    return this.#$r
-  }
+  // get response() {
+  //   return this.#$r
+  // }
 
-  set $r(r) {
-    this.#$r = r
-  }
+  // set $r(r) {
+  //   this.#$r = r
+  // }
 }
 
 type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }
@@ -34,8 +34,8 @@ export type RequestPayload = StringifyPayload | PassThroughPayload
 export interface FetcherOptions {
   base?: string
   autoParse?: boolean
-  transformRequest?: (request: RequestLike) => RequestLike,
-  handleResponse?: (response: Response) => any,
+  transformRequest?: (request: RequestLike) => RequestLike
+  handleResponse?: (response: Response) => any
   fetch?: typeof fetch
   headers?: Record<string, string>
 }
@@ -77,7 +77,7 @@ const fetchy =
      */
     // let url = new URL(url_or_path)
 
-    const method = options.method.toUpperCase();
+    const method = options.method.toUpperCase()
     let search = ''
 
     if (method === 'GET' && payload && typeof payload === 'object') {
@@ -111,9 +111,9 @@ const fetchy =
     //   typeof payload === 'number' ||
     //   Array.isArray(payload) ||
     //   Object.getPrototypeOf(payload).constructor.name === 'Object'
-    const t = typeof payload;
+    const t = typeof payload
     const stringify =
-      !payload ||
+      t === 'undefined' ||
       t === 'string' ||
       t === 'number' ||
       Array.isArray(payload) ||
@@ -146,21 +146,21 @@ const fetchy =
     let error
 
     return f(url, init).then(async (response) => {
-      if (options.handleResponse) return options.handleResponse(response);
+      if (options.handleResponse) return options.handleResponse(response)
 
       if (!response.ok) {
-        error = new StatusError(response.status, response.statusText);
-        error.$r = response;
-      } else if (!options.autoParse) return response;
+        error = new StatusError(response.status, response.statusText)
+        // error.$r = response
+      } else if (!options.autoParse) return response
 
-      const content = await (response.headers.get('content-type')?.includes('json') ? response.json() : response.text());
+      const content = await (response.headers.get('content-type')?.includes('json') ? response.json() : response.text())
 
       if (error) {
-        Object.assign(error, typeof content === 'object' ? content : { message: content || error.message });
-        throw error;
+        Object.assign(error, typeof content === 'object' ? content : { message: content || error.message })
+        throw error
       }
 
-      return content;
+      return content
     })
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,19 +67,20 @@ const fetchy =
     // let url = new URL(url_or_path)
 
     const method = options.method.toUpperCase()
-    let search = ''
+    let [urlBase, queryParams = ''] = url_or_path.split('?')
 
     if (method === 'GET' && payload && typeof payload === 'object') {
-        const merged = new URLSearchParams(url_or_path.split('?')[0])
-        // @ts-expect-error we don't care about this
-        const entries = (payload instanceof URLSearchParams ? payload : new URLSearchParams(payload)).entries()
+        const merged = new URLSearchParams(queryParams)
 
+        // @ts-expect-error ignore this
+        const entries = (payload instanceof URLSearchParams ? payload : new URLSearchParams(payload)).entries()
         for (const [key, value] of entries) merged.append(key, value)
-        search = merged.toString() ? '?' + merged : ''
+
+        queryParams = merged.toString() ? '?' + merged : ''
         payload = null
     }
 
-    const full_url = (options.base || '') + url_or_path + search
+    const full_url = (options.base || '') + urlBase + queryParams
 
     /**
      * If the payload is a POJO, an array or a string, we will stringify it

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,8 +62,6 @@ export type FetchyOptions = { method: string } & FetcherOptions
 const fetchy =
   (options: FetchyOptions): FetchyFunction =>
   async (url_or_path: string, payload?: RequestPayload, fetchOptions?: FetchOptions) => {
-
-
     /**
      * If the request is a `.get(...)` then we want to pass the payload
      * to the URL as query params as passing data in the body is not
@@ -82,23 +80,15 @@ const fetchy =
 
     if (method === 'GET' && payload && typeof payload === 'object') {
         const merged = new URLSearchParams(url_or_path.split('?')[0])
+        // @ts-expect-error we don't care about this
+        const entries = (payload instanceof URLSearchParams ? payload : new URLSearchParams(payload)).entries()
 
-        const entries = payload instanceof URLSearchParams
-            // @ts-expect-error - ignore this
-            ? Array.from(payload.entries())
-            : Object.entries(payload)
-
-        // @ts-expect-error - ignore this
-        for (const [key, value] of entries) {
-            merged.append(key, value)
-        }
-
+        for (const [key, value] of entries) merged.append(key, value)
         search = merged.toString() ? '?' + merged : ''
         payload = undefined
     }
 
     const full_url = (options.base || '') + url_or_path + search
-
 
     /**
      * If the payload is a POJO, an array or a string, we will stringify it

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,10 @@
 export class StatusError extends Error {
   status: number
-  // #$r: Response
 
   constructor(status = 500, message = 'Internal Error.') {
     super(message)
     this.status = status
   }
-
-  // get response() {
-  //   return this.#$r
-  // }
-
-  // set $r(r) {
-  //   this.#$r = r
-  // }
 }
 
 type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }
@@ -85,7 +76,7 @@ const fetchy =
 
         for (const [key, value] of entries) merged.append(key, value)
         search = merged.toString() ? '?' + merged : ''
-        payload = undefined
+        payload = null
     }
 
     const full_url = (options.base || '') + url_or_path + search
@@ -95,19 +86,11 @@ const fetchy =
      * automatically, otherwise we will pass it through as-is.
      */
 
-    // const stringify =
-    //   typeof payload === 'undefined' ||
-    //   typeof payload === 'string' ||
-    //   typeof payload === 'number' ||
-    //   Array.isArray(payload) ||
-    //   Object.getPrototypeOf(payload).constructor.name === 'Object'
     const t = typeof payload
     const stringify =
-      t === 'undefined' ||
-      t === 'string' ||
       t === 'number' ||
       Array.isArray(payload) ||
-      (t === 'object' && payload.constructor === Object)
+      payload?.constructor === Object
 
     const jsonHeaders = stringify ? { 'content-type': 'application/json' } : undefined
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export type RequestPayload = StringifyPayload | PassThroughPayload
 export interface FetcherOptions {
   base?: string
   autoParse?: boolean
-  transformRequest?: (request: RequestLike) => RequestLike
+  transformRequest?: (request: RequestLike) => RequestLike | Promise<RequestLike>
   handleResponse?: (response: Response) => any
   fetch?: typeof fetch
   headers?: Record<string, string>

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,9 +74,9 @@ const fetchy =
 
         // @ts-expect-error ignore this
         const entries = (payload instanceof URLSearchParams ? payload : new URLSearchParams(payload)).entries()
-        for (const [key, value] of entries) merged.append(key, value)
+        for (let [key, value] of entries) merged.append(key, value)
 
-        queryParams = merged.toString() ? '?' + merged : ''
+        queryParams = '?' + merged.toString()
         payload = null
     }
 


### PR DESCRIPTION
## v0.9.x - Changelog
- addresses discord link in README #37 
- allows for async `transformRequest` #36 
- creates more elaborate/useful errors #39 
  - JSON response bodies in error responses are assigned into the error itself, allowing downstream deconstruction
  - if a text response body, `error.message` will take on that text, otherwise it will remain as `response.statusText`
- several minification passes to help offset the size increase
- fixed/simplified logic for what content is automatically stringified
  - no longer stringifies text content (test updated to match) - text should not be turned into JSON
  - stringifies: numbers, arrays, or natural Objects (base constructor === Object)
- fixes bug when using GET requests with query in both url AND payload:
  ```js
  fetcher().get('https://somewhere.com?foo=12', { foo: 10, bar: 'baz' })
  // should return https://somewhere.com?foo=12&foo=10&bar=baz
  ```

## TOTAL SIZE INCREASE
~4 bytes post-minification
