### PR TITLE
Fix missing error message for HTTP error JSON responses

### DIFF
--- a/src/fetcher.spec.ts
+++ b/src/fetcher.spec.ts
@@ -441,7 +441,7 @@ const tests: TestTree = {
           expect(error.status).toBe(404)
           expect(error.response).toBeInstanceOf(Response)
           expect(error.response.status).toBe(404)
-          expect(error.message).toBe('')
+          expect(error.message).toBe('HTTP 404')
         },
         '404 with JSON body returns [error, undefined]': async () => {
           // @ts-ignore
@@ -579,6 +579,7 @@ const tests: TestTree = {
             expect(error.status).toBe(400)
             expect(error.response).toBeInstanceOf(Response)
             expect(error.response.status).toBe(400)
+            expect(error.message).toBe('HTTP 400')
           }
         },
         '500 with text error body': async () => {

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -40,7 +40,7 @@ let handleRequest = async (
   let response = await (options.fetch || fetch)(new Request(url, { ...options, headers })),
     error = response.ok
       ? undefined
-      : Object.assign(new Error(response.statusText), { status: response.status, response })
+      : Object.assign(new Error('HTTP ' + response.status), { status: response.status, response })
 
   // parse response (if allowed)
   if (options.parse ?? 'json') {
@@ -48,7 +48,7 @@ let handleRequest = async (
       response = await response[options.parse ?? 'json']()
 
       if (error && (options.parse ?? 'json') == 'json') {
-        error = { ...error, ...response }
+        Object.assign(error, response)
       }
     } catch (parseError: any) {
       if (!error) {


### PR DESCRIPTION
This PR makes HTTP errors more consistent and easier to handle.

Previously, HTTP errors relied on `response.statusText` for their message, but `statusText` is often empty [like for all HTTP/2 responses](https://developer.mozilla.org/en-US/docs/Web/API/Response/statusText). Also, when an HTTP error response body was valid JSON, the parsed body was merged using object spread, which turns the thrown value into a plain object and drop the `Error`'s `message`.

That is confusing because reading `message` from a caught error is common in JavaScript, and the documented behavior in the [itty-fetcher documentation](https://itty.dev/itty-fetcher/error-handling) includes the `message` property.

## Before

```js
try {
  await fetcher().get('<URL with non-2xx status and JSON response>')
} catch (e) {
  console.error(e.toString()) // "[object Object]"
  console.error('Is error', e instanceof Error) // false
  console.error('Message', e.message) // undefined
}
```

## After

```js
try {
  await fetcher().get('<URL with non-2xx status and JSON response>')
} catch (e) {
  console.error(e.toString()) // "Error: HTTP 404"
  console.error('Is error', e instanceof Error) // true
  console.error('Message', e.message) // "HTTP 404"
}
```

This change uses a stable fallback message and preserves the `Error` instance when adding JSON error body fields. These changes are minimal, with only 9 additional total characters after minimization, to avoid increasing the bundle size more than necessary 🚀 